### PR TITLE
Add server API

### DIFF
--- a/experiments/fourier_training/graphite-demo/server.js
+++ b/experiments/fourier_training/graphite-demo/server.js
@@ -1,0 +1,36 @@
+const express = require('express');
+const app = express();
+const port = 3000;
+
+// Fake data for tasks
+const tasks = [
+  {
+    id: 1,
+    description: 'Complete monthly financial report'
+  },
+  {
+    id: 2,
+    description: 'Plan team building activity'
+  },
+  {
+    id: 3,
+    description: 'Update project documentation'
+  }
+];
+
+app.get('/search', (req, res) => {
+  // Retrieve the query parameter
+  const query = req.query.query?.toLowerCase() || '';
+
+  // Filter tasks based on the query
+  const filteredTasks = tasks.filter(task => task.description.toLowerCase().includes(query));
+
+  // Sort the filtered tasks alphabetically by description
+  const sortedTasks = filteredTasks.sort((a, b) => a.description.localeCompare(b.description));
+
+  res.json(sortedTasks);
+});
+
+app.listen(port, () => {
+  console.log(`Server running on port ${port}`);
+});


### PR DESCRIPTION
### TL;DR
Added a new Express server with task search functionality

### What changed?
Created a new server.js file that implements a basic Express server with a `/search` endpoint. The server maintains a static list of tasks and provides filtering capabilities based on task descriptions.

### How to test?
1. Start the server: `node server.js`
2. Send a GET request to `http://localhost:3000/search?query=report`
3. Verify that the response returns filtered tasks matching the search query
4. Try different search terms to ensure filtering works correctly

### Why make this change?
To provide a simple API endpoint for searching through task descriptions, which can be used as a foundation for building task management features in the application.